### PR TITLE
Update build_docs_pages_static.yml

### DIFF
--- a/.github/workflows/build_docs_pages_static.yml
+++ b/.github/workflows/build_docs_pages_static.yml
@@ -17,9 +17,3 @@ jobs:
 
     - run: dotnet tool update -g docfx
     - run: docfx docfx_project/docfx.json
-
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_site


### PR DESCRIPTION
Deployment step unnecessary as we are using GitHub's basic deployment action to deploy the static pages under _site